### PR TITLE
chore: add file list to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,5 +34,9 @@
   "bugs": {
     "url": "https://github.com/daxelrod/jowl/issues"
   },
-  "homepage": "https://github.com/daxelrod/jowl#readme"
+  "homepage": "https://github.com/daxelrod/jowl#readme",
+  "files": [
+    "README.md",
+    "src"
+  ]
 }


### PR DESCRIPTION
Reduce bloat by including only the necessary production runtime
files in the package. Also, keep out temporary files that happen
to be in my development directory.