### PR TITLE
feat: add p() and --quiet

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,8 +1,10 @@
 # Jowl Reference
 
-    jowl  <command>`
+    jowl [options] <command>`
 
 Jowl takes JSON on standard in, and writes the JSON-strigified value of `command` to standard out.
+
+The only current option is [`--quiet`](#quiet) (or `-q` for short) which disables writing of `command`'s value to standard out.
 
 ## Command
 
@@ -18,6 +20,15 @@ $ echo 'true' | jowl '{"name": "jowl", "awesome": d}'
 
 It is run in something close to `var value = eval('(' + command + ') )` to ensure that curly
 braces are interepreted as object constructors rather than blocks.
+
+## Input and Output
+
+**Standard In** is expected to be a string representing a single JSON object. (This may eventually be
+expanded to a stream of multiple JSON objects.) Processing does not start until input ends. The parsed
+JSON will be available as the `d` variable.
+
+The value of `command` will have `.value()` called on it if it is a Lodash chain. The results of this
+will be run through JSON.stringify and output to **Standard Out** (except in [quiet mode](#quiet)).
 
 ## Variables
 
@@ -37,16 +48,36 @@ The following variables are available within `command`'s execution environment:
 
 Variable | Value
 ---------|------
-_ | [Lodash](https://lodash.com/docs)
-d | Parsed input **data**
-c | **[Chain](https://lodash.com/docs#chain)**. Shortcut for `_.chain(d)`
+`_` | [Lodash](https://lodash.com/docs)
+`d` | Parsed input **data**
+`c` | **[Chain](https://lodash.com/docs#chain)**. Shortcut for `_.chain(d)`
+`p()` | **[Print](#print-function)**. Pretty-prints its argument
 
-## Input and Output
+### Print Function
 
-**Standard In** is expected to be a string representing a single JSON object. (This may eventually be
-expanded to a stream of multiple JSON objects.) Processing does not start until input ends. The parsed
-JSON will be available as the `d` variable.
+```
+$ echo '[1,2,3]' | jowl -q 'c.each(p)'
+1
+2
+3
+```
 
-The value of `command` will have `.value()` called on it if it is a Lodash chain. The results of this
-will be run through JSON.stringify and output to **Standard Out**.
+`p()` prints its first argument to standard out. This is useful for creating non-JSON output, or when it makes more sense to write your command imperatively rather than
+a transformation to a different data structure.
 
+It is often used with the [`--quiet`](#quiet) option so that the results of the command are not written to standard out
+in addition to `p()`'s output.
+
+`p()` is actually a call to [`console.json`](https://www.npmjs.com/package/console.json), which prints a single string
+or number verbatim, but pretty-prints more complex data structures as JSON.
+
+Its return value is the argument that was passed in, for maximum utility when chaining.
+
+## Options
+
+### Quiet
+
+`--quiet` or `-q`
+
+Disables the  writing the the value of `command` to standard out.
+The output of the [Print Function`p()`](#print) is still written.

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "bin": "src/bin/index.js",
   "dependencies": {
     "commander": "^2.9.0",
+    "console.json": "^0.2.1",
     "gulp-jscs": "^3.0.2",
     "lodash": "^3.10.1"
   },

--- a/src/bin/index.js
+++ b/src/bin/index.js
@@ -8,11 +8,16 @@ var command;
 
 program
   .version('0.2.0')
+  .option('-q, --quiet', 'Supress output of command return value')
   .arguments('<command>')
   .action(function (cmd) {
     command = cmd;
   })
   .parse(process.argv);
+
+var options = {
+  quiet: program.quiet,
+};
 
 var data = '';
 
@@ -26,6 +31,9 @@ process.stdin.on('readable', function () {
 });
 
 process.stdin.on('end', function () {
-  var result = format.runFormat(data, command);
-  console.log(result);
+  var result = format.runFormat(data, command, options);
+
+  if (result !== null) {
+    console.log(result);
+  }
 });

--- a/src/lib/format.js
+++ b/src/lib/format.js
@@ -19,10 +19,12 @@ format.runFormat = function (json, command, options) {
   var data = this.parseInput(json);
   var result = run.run(data, command);
 
-  // options might be undefined if called from tests
-  var output = _.get(options, 'quiet') ? null : this.formatOutput(result);
+  // Need to unconditionally stringify because _.chain is lazy and
+  // we need p() output even in quiet mode
+  var output = this.formatOutput(result);
 
-  return output;
+  // options might be undefined if called from tests
+  return _.get(options, 'quiet') ? null : output;
 };
 
 module.exports = format;

--- a/src/lib/format.js
+++ b/src/lib/format.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var _ = require('lodash');
+
 var run = require('./run');
 
 var format = {};
@@ -12,10 +14,15 @@ format.formatOutput = function (resultData) {
   return JSON.stringify(resultData, null, 4);
 };
 
-format.runFormat = function (json, command) {
+// Returns either a string to be output, or null if output should be supressed
+format.runFormat = function (json, command, options) {
   var data = this.parseInput(json);
   var result = run.run(data, command);
-  return this.formatOutput(result);
+
+  // options might be undefined if called from tests
+  var output = _.get(options, 'quiet') ? null : this.formatOutput(result);
+
+  return output;
 };
 
 module.exports = format;

--- a/src/lib/run.js
+++ b/src/lib/run.js
@@ -6,6 +6,14 @@ require('console.json'); // Injects itself directly into the console object
 
 var run = {};
 
+function p() {
+  // console.json can take an unlimited number of arguments
+  console.json.apply(console, arguments); // returns undefined
+
+  // can't return more than one value; the first is least surprising
+  return arguments[0];
+}
+
 run.run = function (data, command) {
   // Parens are needed to disambiguate that curly braces are an object and
   // not a block.
@@ -17,7 +25,7 @@ run.run = function (data, command) {
     _: _,
     d: data,
     c: _.chain(data),
-    p: console.json,
+    p: p,
   });
 };
 

--- a/src/lib/run.js
+++ b/src/lib/run.js
@@ -6,12 +6,10 @@ require('console.json'); // Injects itself directly into the console object
 
 var run = {};
 
-function p() {
-  // console.json can take an unlimited number of arguments
-  console.json.apply(console, arguments); // returns undefined
-
-  // can't return more than one value; the first is least surprising
-  return arguments[0];
+function p(data) {
+  // intentionally limit to just one argument
+  console.json(data); // returns undefined
+  return data;
 }
 
 run.run = function (data, command) {

--- a/src/lib/run.js
+++ b/src/lib/run.js
@@ -2,6 +2,7 @@
 
 var _ = require('lodash');
 var vm = require('vm');
+require('console.json'); // Injects itself directly into the console object
 
 var run = {};
 
@@ -16,6 +17,7 @@ run.run = function (data, command) {
     _: _,
     d: data,
     c: _.chain(data),
+    p: console.json,
   });
 };
 

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -73,16 +73,23 @@ describe('jowl cli', function () {
     });
   });
 
-  it('should should print using p', function (done) {
+  it('should print using p', function (done) {
     runCommand(jowlCommand, [
         'p(d[0])',
       ], '["one", "two"]', function (err, result) {
-      expect(result).to.have.property('stderr').that.is.undefined; // jshint ignore: line
-      expect(result).to.have.property('stdout', 'one\nundefined\n');
-      expect(result).to.have.property('status', 0);
+        // It is not defined whether p or the value will be printed first
+        expect(result).to.have.property('stdout').that.contains(
+          'one\n', 'output of p'
+        );
+        expect(result).to.have.property('stdout').that.contains(
+          '"one"\n', 'output of value'
+        );
+        expect(result).to.have.property('stderr').that.is.undefined; // jshint ignore: line
+        expect(result).to.have.property('status', 0);
 
-      done();
-    });
+        done();
+      }
+    );
   });
 
   describe('in quiet mode', function () {

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -120,5 +120,19 @@ describe('jowl cli', function () {
         }
       );
     });
+
+    it('should still print using a chain', function (done) {
+      runCommand(jowlCommand, [
+          '-q',
+          'c.each(p)',
+        ], '["one", "two"]', function (err, result) {
+          expect(result).to.have.property('stdout', 'one\ntwo\n');
+          expect(result).to.have.property('status', 0);
+          expect(result).to.have.property('stderr').that.is.undefined; // jshint ignore: line
+
+          done();
+        }
+      );
+    });
   });
 });

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -72,4 +72,16 @@ describe('jowl cli', function () {
       done();
     });
   });
+
+  it('should should print using p', function (done) {
+    runCommand(jowlCommand, [
+        'p(d[0])',
+      ], '["one", "two"]', function (err, result) {
+      expect(result).to.have.property('stderr').that.is.undefined; // jshint ignore: line
+      expect(result).to.have.property('stdout', 'one\nundefined\n');
+      expect(result).to.have.property('status', 0);
+
+      done();
+    });
+  });
 });

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -84,4 +84,34 @@ describe('jowl cli', function () {
       done();
     });
   });
+
+  describe('in quiet mode', function () {
+    it('should supress output of expression return value', function (done) {
+      runCommand(jowlCommand, [
+          '-q',
+          'd[0]',
+        ], '["one", "two"]', function (err, result) {
+          expect(result).to.have.property('stdout').that.is.undefined; // jshint ignore:line
+          expect(result).to.have.property('status', 0);
+          expect(result).to.have.property('stderr').that.is.undefined; // jshint ignore: line
+
+          done();
+        }
+      );
+    });
+
+    it('should still print using p', function (done) {
+      runCommand(jowlCommand, [
+          '--quiet',
+          'p(d[0])',
+        ], '["one", "two"]', function (err, result) {
+          expect(result).to.have.property('stdout', 'one\n');
+          expect(result).to.have.property('status', 0);
+          expect(result).to.have.property('stderr').that.is.undefined; // jshint ignore: line
+
+          done();
+        }
+      );
+    });
+  });
 });

--- a/test/unit/lib/format.js
+++ b/test/unit/lib/format.js
@@ -87,5 +87,11 @@ describe('formatting library', function () {
       sinon.assert.calledOnce(format.formatOutput);
       sinon.assert.calledWithExactly(format.formatOutput, 'one');
     });
+
+    it('should return null in quiet mode', function () {
+      expect(
+        format.runFormat(json, command, { quiet: true })
+      ).to.be.null; // jshint ignore: line
+    });
   });
 });

--- a/test/unit/lib/run.js
+++ b/test/unit/lib/run.js
@@ -63,6 +63,12 @@ describe('Command runner library', function () {
           sinon.assert.calledOnce(console.json);
           sinon.assert.calledWithExactly(console.json, data);
         });
+
+        it('should return the first item passed to it', function () {
+          expect(
+            run.run(data, 'p(d,d)')
+          ).to.eql(data);
+        });
       });
 
       it('should not include other variables leaked into scope', function () {

--- a/test/unit/lib/run.js
+++ b/test/unit/lib/run.js
@@ -3,6 +3,7 @@
 var expect = require('chai').expect;
 var _ = require('lodash');
 var run = require('../../../src/lib/run');
+var sinon = require('sinon');
 
 describe('Command runner library', function () {
   describe('run method', function () {
@@ -44,6 +45,24 @@ describe('Command runner library', function () {
         expect(
           run.run(data, 'c.get("0.words").map(_.capitalize).value()')
         ).to.eql(['Foo', 'Bar']);
+      });
+
+      describe('"p"', function () {
+        beforeEach(function () {
+          sinon.spy(console, 'json');
+        });
+
+        afterEach(function () {
+          console.json.restore();
+        });
+
+        it('should include console.json as "p"', function () {
+          // console.json does not document its return value,
+          // so don't test for it
+          run.run(data, 'p(d)');
+          sinon.assert.calledOnce(console.json);
+          sinon.assert.calledWithExactly(console.json, data);
+        });
       });
 
       it('should not include other variables leaked into scope', function () {


### PR DESCRIPTION
Add `p` function for printing to standard out, and associated `--quiet` flag
to suppress default output of the expression result.