### PR TITLE
Improve installation and contribution docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,23 +101,39 @@ Rules are checked automatically at build time.
 
 ### Commit Standards
 
-Please follow [The Seven Rules of a Great Commit Message](https://chris.beams.io/posts/git-commit/#seven-rules) except for #3 (capitalize the first word).
+```text
+feat(run): add chain runner
+
+Add command runner which works in chain mode. This library will
+be used by the executable, which will handle command line
+processing and JSON parsing and serialization.
+
+In chain mode, the command is prefixed with a Lodash chain with
+the data as the context. After the command, .value() is
+automatically called.
+```
+
+Please follow [The Seven Rules of a Great Commit Message](https://chris.beams.io/posts/git-commit/#seven-rules) except for #3 (please don't capitalize the first word).
 
 Commit also messages conform to the [Angular Git Commit Guidelines](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit)
 except that the `scope` in the parentheses should be one of the following:
 
-* run
-* cli
-* lint
-* format
-* readme (docs only)
-* reference (docs only)
-* help (docs only)
-* travis (chore only)
-* gulp (chore only)
-* release (chore only)
-* deps (chore only)
-* integration (test only)
+* **General**
+  * `run`
+  * `cli`
+  * `lint`
+  * `format`
+* **`docs` type only**
+  * `readme`
+  * `reference`
+  * `help` (text output by running `jowl --help`)
+* **`chore` type only**
+  * `ci` (continuous integration configuration)
+  * `gulp`
+  * `release`
+  * `deps`
+* **`test` type only**
+  * `integration`
 
 Note that unlike Angular, the changelogs are not generated automatically from commit messages.
 I do not believe a one-to-one correspondance between commit messages and changelog lines is useful.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,7 @@
 # Contributing
 
+[![Build Status](https://travis-ci.org/daxelrod/jowl.svg?branch=master)](https://travis-ci.org/daxelrod/jowl)
+
 I'm glad you find Jowl useful enough that you want to help out! Thank you!
 
 Please note that I get time to work on Jowl in fits and bursts, so issues and pull requests may sit for up to a month before I have a chance to initially respond to them.

--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@
 
 <!-- markdownlint-disable MD014 -->
 
-    $ jowl '{"messages" : _.map(d, "commit.author.date")}' < commits.json
+```bash
+$ jowl '{"messages" : _.map(d, "commit.author.date")}' < commits.json
+```
 
-<!-- markdownlint-disable MD014 -->
+<!-- markdownlint-enable MD014 -->
 
 Jowl is a command-line filter for JSON expressions that uses plain JavaScript
 with [Lodash](https://lodash.com/). It takes JSON on standard in, and writes
@@ -17,6 +19,14 @@ Jowl's goals are:
 * **Easy to learn**: Syntax you already know, as little magic as pratical
 * **Concise**: intended to be used in one-liners, where keystrokes are at a premium
 * **Convenient**: Do What I Mean shortcuts exist, but are not required for use
+
+## Installation
+
+Jowl requires [NodeJS 4 or greater](https://nodejs.org/en/download/).
+
+```bash
+npm install --global --production jowl
+```
 
 ## Reference
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Jowl - JSON Operations With Lodash
 
-[![Build Status](https://travis-ci.org/daxelrod/jowl.svg?branch=master)](https://travis-ci.org/daxelrod/jowl)
-
 <!-- markdownlint-disable MD014 -->
 
 ```bash


### PR DESCRIPTION
Add installation instructions, move Travis badge to CONTRIBUTING, and clarify commit standards.