### PR TITLE
feat(cli): pass through when no command

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,6 +1,6 @@
 # Jowl Reference
 
-    jowl [options] <command>
+    jowl [options] [command]
 
 Jowl takes JSON on standard in, and writes the JSON-strigified value of `command` to standard out.
 
@@ -22,6 +22,8 @@ $ echo 'true' | jowl '{"name": "jowl", "awesome": d}'
 
 It is run in something close to `var value = eval('(' + command + ') )` to ensure that curly
 braces are interepreted as object constructors rather than blocks.
+
+If `command` is not supplied, Jowl simply acts as a pretty-printer.
 
 ## Input and Output
 

--- a/src/bin/index.js
+++ b/src/bin/index.js
@@ -10,14 +10,14 @@ let command;
 program
   .version('0.3.0')
   .option('-q, --quiet', 'Supress output of command return value')
-  .arguments('<command>')
+  .arguments('[command]')
   .action((cmd) => {
     command = cmd;
   })
   .on('--help', () => {
     console.log(
       '  Jowl is a command-line filter for JSON expressions that uses\n' +
-      '  JavaScript with Lodash as its <command>.\n' +
+      '  JavaScript with Lodash as its command argument.\n' +
       '\n' +
       '  It takes JSON on standard in and writes JSON to standard out.\n' +
       '\n' +
@@ -30,6 +30,11 @@ program
 const options = {
   quiet: program.quiet,
 };
+
+if (command == null) {
+  // If no command was specified, pass through the JSON and act as a pretty-printer
+  command = 'd';
+}
 
 let data = '';
 

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -147,4 +147,15 @@ describe('jowl cli', () => {
       done();
     });
   });
+
+  it('should treat no command as passthrough', (done) => {
+    runCommand(jowlCommand, [], '["one", "two"]', (err, result) => {
+      const jsonFormatted = '[\n    "one",\n    "two"\n]\n';
+      expect(result).to.have.property('stdout', jsonFormatted);
+      expect(result).to.have.property('stderr').that.is.undefined;
+      expect(result).to.have.property('status', 0);
+
+      done();
+    });
+  });
 });


### PR DESCRIPTION
If the user does not supply a JavaScript command, treat it as if they
had supplied a command of 'd' rather than simply printing `undefined`.
This has the effect of turning jowl with no arguments into a
pretty-printer.

This was inspired by my own failures to use jowl correctly while
testing it on Windows and wondering what terrible shell escaping was
turning all of the stdin expressions into undefined.

Originally, I implemented an error message to let the user know they
needed to supply one, but a default passthrough is much more useful.