### PR TITLE
style: comply with new lint rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -37,13 +37,6 @@
     // that we have lexical scoping, it"s not as dangerous as it once was.
     "no-shadow": "off",
 
-    // While the style guide talks about logical operators at the beginning of
-    // lines within control statements, it appears it was intended in
-    // https://github.com/airbnb/javascript/pull/1600 to apply to all operators
-    // next to line breaks. Disable this for now, but it makes sense to eventually
-    // comply.
-    "operator-linebreak": "off",
-
     // A reasonable ES6 rule to eventually comply with.
     "prefer-destructuring": "off",
 

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -37,9 +37,6 @@
     // that we have lexical scoping, it"s not as dangerous as it once was.
     "no-shadow": "off",
 
-    // A reasonable ES6 rule to eventually comply with.
-    "prefer-destructuring": "off",
-
     // Not explicitly mentioned in the styleguide, but entirely reasonable.
     // Will eventually comply.
     "import/order": "off"

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -28,13 +28,13 @@
     "no-console": "off",
 
     // Airbnb sets this to "never" even though their written style guide
-    // never actually mentions it. Babel inserts it for them, but we"re
+    // never actually mentions it. Babel inserts it for them, but we're
     // not using Babel.
     "strict": ["error", "safe"],
 
     // The Airbnb style guide never mentions this, but the airbnb eslint rules
     // consider it an error. Shadowing is a useful language feature, and now
-    // that we have lexical scoping, it"s not as dangerous as it once was.
+    // that we have lexical scoping, it's not as dangerous as it once was.
     "no-shadow": "off"
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -35,10 +35,6 @@
     // The Airbnb style guide never mentions this, but the airbnb eslint rules
     // consider it an error. Shadowing is a useful language feature, and now
     // that we have lexical scoping, it"s not as dangerous as it once was.
-    "no-shadow": "off",
-
-    // Not explicitly mentioned in the styleguide, but entirely reasonable.
-    // Will eventually comply.
-    "import/order": "off"
+    "no-shadow": "off"
   }
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,7 +101,7 @@ New changes should make reasonable efforts not to break compatability with end-o
 
 Jowl is written in ES6.
 
-Source code conforms to the [Airbnb Style Guide](https://github.com/airbnb/javascript) with a few [exceptions](.eslintrc.js).
+Source code conforms to the [Airbnb Style Guide](https://github.com/airbnb/javascript) with a few [exceptions](.eslintrc.json).
 This is checked automatically at build time.
 
 Markdown conforms to [Markdownlint rules](https://github.com/mivok/markdownlint/blob/master/docs/RULES.md) except for MD013 Line Length.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-[![Linux Build Status](https://circleci.com/gh/daxelrod/jowl.svg?style=svg)](https://circleci.com/gh/daxelrod/jowl) [![Windows Build Status](https://ci.appveyor.com/api/projects/status/github/daxelrod/jowl/branch/master)](https://ci.appveyor.com/project/daxelrod/jowl)
+[![Linux Build Status](https://circleci.com/gh/daxelrod/jowl.svg?style=svg)](https://circleci.com/gh/daxelrod/jowl) [![Windows Build Status](https://ci.appveyor.com/api/projects/status/awi03ipcuan2ttco/branch/master?svg=true)](https://ci.appveyor.com/project/daxelrod/jowl)
 
 I'm glad you find Jowl useful enough that you want to help out! Thank you!
 

--- a/src/bin/jowl.js
+++ b/src/bin/jowl.js
@@ -16,13 +16,13 @@ program
   })
   .on('--help', () => {
     console.log(
-      '  Jowl is a command-line filter for JSON expressions that uses\n' +
-      '  JavaScript with Lodash as its command argument.\n' +
-      '\n' +
-      '  It takes JSON on standard in and writes JSON to standard out.\n' +
-      '\n' +
-      '  For a complete reference, see\n' +
-      '  https://github.com/daxelrod/jowl/blob/master/docs/reference.md'
+      '  Jowl is a command-line filter for JSON expressions that uses\n'
+      + '  JavaScript with Lodash as its command argument.\n'
+      + '\n'
+      + '  It takes JSON on standard in and writes JSON to standard out.\n'
+      + '\n'
+      + '  For a complete reference, see\n'
+      + '  https://github.com/daxelrod/jowl/blob/master/docs/reference.md'
     );
   })
   .parse(process.argv);

--- a/test/integration/jowl.js
+++ b/test/integration/jowl.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const expect = require('chai').expect;
+const { expect } = require('chai');
 const spawn = require('cross-spawn');
 
 const jowlCommand = 'src/bin/jowl.js';

--- a/test/unit/lib/format.js
+++ b/test/unit/lib/format.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const expect = require('chai').expect;
+const { expect } = require('chai');
 const sinon = require('sinon');
 const format = require('../../../src/lib/format');
 const run = require('../../../src/lib/run');

--- a/test/unit/lib/run.js
+++ b/test/unit/lib/run.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const expect = require('chai').expect;
+const { expect } = require('chai');
 const _ = require('lodash');
 const run = require('../../../src/lib/run');
 const sinon = require('sinon');

--- a/test/unit/lib/run.js
+++ b/test/unit/lib/run.js
@@ -2,8 +2,8 @@
 
 const { expect } = require('chai');
 const _ = require('lodash');
-const run = require('../../../src/lib/run');
 const sinon = require('sinon');
+const run = require('../../../src/lib/run');
 
 describe('Command runner library', () => {
   describe('run method', () => {


### PR DESCRIPTION
Comply with the new lint rules enforced by our recent upgrade to a newer airbnb eslint plugin.

* operator-linebreak: move `+` operator to beginning of line on a couple of joined multiline strings
* prefer-destructuring: get the chai expect function through destructuring rather than calling it on the import on the rhs
* import/order: move internal require to end of list

Additionally fix a couple of eslint and doc typos.