### PR TITLE
feat(format): add color syntax highlighting

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -32,7 +32,12 @@ expanded to a stream of multiple JSON objects.) Processing does not start until 
 JSON will be available as the `d` variable.
 
 The value of `command` will have `.value()` called on it if it is a Lodash chain. The results of this
-will be run through JSON.stringify and output to **Standard Out** (except in [quiet mode](#quiet)).
+will be run through JSON.stringify, optionally syntax highlighted, and output to **Standard Out** (except in [quiet mode](#quiet)).
+
+Syntax highlighting will be automatically applied when **Standard Out** is a color-supporting TTY by adding ANSI color codes.
+ANSI color codes are not added if not outputting to a TTY.
+The specific colors used are subject to change in future versions without this being considered a breaking change.
+See the [`--color` & `--no-color` options](#color) or the [`FORCE_COLOR` environment variable](#force-color).
 
 ## Variables
 
@@ -85,3 +90,29 @@ Its return value is the argument that was passed in, for maximum utility when ch
 
 Disables the  writing the the value of `command` to standard out.
 The output of the [Print Function`p()`](#print) is still written.
+
+### Color
+
+`--color` or instead `--no-color`
+
+By default, Jowl will use various heuristics to decide whether to output ANSI color codes to syntax-highlight the value of `command`.
+
+These mutually-exclusive options override the heuristics to force always writing ANSI color codes (`--color`) or never writing them (`--no-color`).
+
+Specifying both options will result in undefined behavior and will likely be disallowed later.
+
+See also the [`FORCE_COLOR` environment variable](#force-color) environment variable as another mechanism to control this behavior.
+
+## Environment Variables
+
+### Force Color
+
+`FORCE_COLOR`
+
+By default, Jowl will use various heuristics to decide whether to output ANSI color codes to syntax-highlight the value of `command`.
+
+This environment variable overrides both these heuristics and the [`--color` or `--no-color` options](#color).
+
+When set to `1`, forces always writing ANSI color codes.
+
+When set to `0`, forces never writing ANSI color codes.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -13,8 +13,8 @@ The only current option is [`--quiet`](#quiet) (or `-q` for short) which disable
 ```bash
 $ echo 'true' | jowl '{"name": "jowl", "awesome": d}'
 {
-    "name": "jowl",
-    "awesome": "true"
+  "name": "jowl",
+  "awesome": "true"
 }
 ```
 
@@ -39,12 +39,12 @@ will be run through JSON.stringify and output to **Standard Out** (except in [qu
 ```bash
 $ echo '[{"name":"jowl"}, {"name":"jq"}, {"name":"underscore"}]' | jowl '{"all": c.map("name").value(), "newest": _.capitalize(d[0].name)}'
 {
-    "all": [
-        "jowl",
-        "jq",
-        "underscore"
-    ],
-    "newest": "Jowl"
+  "all": [
+    "jowl",
+    "jq",
+    "underscore"
+  ],
+  "newest": "Jowl"
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -4,8 +4,10 @@
   "description": "CLI for JSON operations with Lodash",
   "bin": "src/bin/jowl.js",
   "dependencies": {
+    "chalk": "^2.4.1",
     "commander": "^2.9.0",
     "console.json": "^0.2.1",
+    "json-colorizer": "^2.2.2",
     "lodash": "^4.17.4"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "CLI for JSON operations with Lodash",
   "bin": "src/bin/jowl.js",
   "dependencies": {
-    "chalk": "^2.4.1",
     "commander": "^2.9.0",
     "console.json": "^0.2.1",
     "json-colorizer": "^2.2.2",
@@ -12,6 +11,7 @@
   },
   "devDependencies": {
     "chai": "^3.4.1",
+    "chalk": "^2.4.1",
     "cross-spawn": "^5.1.0",
     "eslint": "^5.0.0",
     "eslint-config-airbnb-base": "^14.2.1",

--- a/src/bin/jowl.js
+++ b/src/bin/jowl.js
@@ -10,6 +10,8 @@ let command;
 program
   .version('1.0.0')
   .option('-q, --quiet', 'Supress output of command return value')
+  .option('--color', 'Always produce color output even if STDOUT would not support it')
+  .option('--no-color', 'Never produce color output even if STDOUT would support it')
   .arguments('[command]')
   .action((cmd) => {
     command = cmd;

--- a/src/lib/format.js
+++ b/src/lib/format.js
@@ -9,7 +9,7 @@ format.parseInput = function parseInput(input) {
 };
 
 format.formatOutput = function formatOutput(resultData) {
-  return JSON.stringify(resultData, null, 4);
+  return JSON.stringify(resultData, null, 2);
 };
 
 // Returns either a string to be output, or null if output should be supressed

--- a/src/lib/format.js
+++ b/src/lib/format.js
@@ -1,15 +1,28 @@
 const _ = require('lodash');
-
+const colorize = require('json-colorizer');
+const chalk = require('chalk');
 const run = require('./run');
 
 const format = {};
+
+// Make json-colorizer's single exported function a method
+// so that we can hook it in unit tests. This is ugly,
+// but is more straightforward than another dependency
+// that redefines how require() works.
+format.jsonColorizer = colorize;
 
 format.parseInput = function parseInput(input) {
   return JSON.parse(input);
 };
 
 format.formatOutput = function formatOutput(resultData) {
-  return JSON.stringify(resultData, null, 2);
+  // For now, disable syntax coloring
+  chalk.level = 0;
+
+  // We must stringify the JSON ourselves before passing it
+  // to json-colorizer because we may be serializing a single
+  // string, which json-colorizer would try to parse as json
+  return this.jsonColorizer(JSON.stringify(resultData, null, 2), {});
 };
 
 // Returns either a string to be output, or null if output should be supressed

--- a/src/lib/format.js
+++ b/src/lib/format.js
@@ -1,6 +1,5 @@
 const _ = require('lodash');
 const colorize = require('json-colorizer');
-const chalk = require('chalk');
 const run = require('./run');
 
 const format = {};
@@ -16,13 +15,22 @@ format.parseInput = function parseInput(input) {
 };
 
 format.formatOutput = function formatOutput(resultData) {
-  // For now, disable syntax coloring
-  chalk.level = 0;
-
   // We must stringify the JSON ourselves before passing it
   // to json-colorizer because we may be serializing a single
   // string, which json-colorizer would try to parse as json
-  return this.jsonColorizer(JSON.stringify(resultData, null, 2), {});
+  return this.jsonColorizer(JSON.stringify(resultData, null, 2), {
+    colors: {
+      STRING_KEY: 'cyan', // On terminals where pure blue defaults to 0000FF, it can be hard to read against black
+      STRING_LITERAL: 'reset', // The default color is likely to be the most readable
+      NUMBER_LITERAL: 'green.bold',
+      BOOLEAN_LITERAL: 'magenta', // Don't want to make this red or green because of associations with true and false
+      NULL_LITERAL: 'red',
+      BRACE: 'reset', // Because of indentation, visually distinct anyway
+      BRACKET: 'reset', // Same as brace
+      COLON: 'reset', // Visually distinct from other tokens without special coloring
+      COMMA: 'gray', // These appear at entirely predictable places, so they can be less emphasized
+    },
+  });
 };
 
 // Returns either a string to be output, or null if output should be supressed

--- a/test/integration/jowl.js
+++ b/test/integration/jowl.js
@@ -69,7 +69,7 @@ describe('jowl cli', () => {
           'bar',
           'one',
         ],
-      }, null, 4)}\n`);
+      }, null, 2)}\n`);
       expect(result).to.have.property('status', 0);
 
       done();
@@ -150,7 +150,7 @@ describe('jowl cli', () => {
 
   it('should treat no command as passthrough', (done) => {
     runCommand(jowlCommand, [], '["one", "two"]', (err, result) => {
-      const jsonFormatted = '[\n    "one",\n    "two"\n]\n';
+      const jsonFormatted = '[\n  "one",\n  "two"\n]\n';
       expect(result).to.have.property('stdout', jsonFormatted);
       expect(result).to.have.property('stderr').that.is.undefined;
       expect(result).to.have.property('status', 0);

--- a/test/integration/jowl.js
+++ b/test/integration/jowl.js
@@ -1,12 +1,21 @@
 'use strict';
 
 const { expect } = require('chai');
+const globalChalk = require('chalk');
 const spawn = require('cross-spawn');
 
 const jowlCommand = 'src/bin/jowl.js';
 
-function runCommand(command, args, stdin, callback) {
-  const child = spawn(command, args);
+function runCommand(command, args, stdin, env, callback) {
+  const defaultEnv = {
+    HOME: process.env.HOME,
+    PATH: process.env.PATH,
+    SHELL: process.env.shell,
+  };
+
+  const commandEnv = Object.assign(defaultEnv, env);
+
+  const child = spawn(command, args, { env: commandEnv });
   let stdout;
   let stderr;
 
@@ -43,11 +52,22 @@ function runCommand(command, args, stdin, callback) {
   });
 }
 
+function generateColorString(chalkLevel) {
+  const chalk = new globalChalk.constructor({ level: chalkLevel });
+  return `${chalk.reset('{')}
+  ${chalk.cyan('"STRING_LITERAL"')}${chalk.reset(':')} ${chalk.reset('"yay a string"')}${chalk.gray(',')}
+  ${chalk.cyan('"NUMBER_LITERAL"')}${chalk.reset(':')} ${chalk.green.bold('12.1')}${chalk.gray(',')}
+  ${chalk.cyan('"BOOLEAN_LITERAL"')}${chalk.reset(':')} ${chalk.magenta('true')}${chalk.gray(',')}
+  ${chalk.cyan('"NULL_LITERAL"')}${chalk.reset(':')} ${chalk.red('null')}${chalk.gray(',')}
+  ${chalk.cyan('"BRACKET"')}${chalk.reset(':')} ${chalk.reset('[')}${chalk.reset(']')}
+${chalk.reset('}')}`;
+}
+
 describe('jowl cli', () => {
   it('should run', (done) => {
     runCommand(jowlCommand, [
       'd[0]',
-    ], '["one", "two"]', (err, result) => {
+    ], '["one", "two"]', {}, (err, result) => {
       expect(result).to.have.property('stderr').that.is.undefined;
       expect(result).to.have.property('stdout', '"one"\n');
       expect(result).to.have.property('status', 0);
@@ -59,7 +79,7 @@ describe('jowl cli', () => {
   it('should handle chains within the command', (done) => {
     runCommand(jowlCommand, [
       '_.chain({key: {foo: c}, array: ["bar", c]})',
-    ], '"one"', (err, result) => {
+    ], '"one"', {}, (err, result) => {
       expect(result).to.have.property('stderr').that.is.undefined;
       expect(result).to.have.property('stdout', `${JSON.stringify({
         key: {
@@ -79,7 +99,7 @@ describe('jowl cli', () => {
   it('should print using p', (done) => {
     runCommand(jowlCommand, [
       'p(d[0])',
-    ], '["one", "two"]', (err, result) => {
+    ], '["one", "two"]', {}, (err, result) => {
       // It is not defined whether p or the value will be printed first
       expect(result).to.have.property('stdout').that.contains(
         'one\n', 'output of p'
@@ -99,7 +119,7 @@ describe('jowl cli', () => {
       runCommand(jowlCommand, [
         '-q',
         'd[0]',
-      ], '["one", "two"]', (err, result) => {
+      ], '["one", "two"]', {}, (err, result) => {
         expect(result).to.have.property('stdout').that.is.undefined;
         expect(result).to.have.property('status', 0);
         expect(result).to.have.property('stderr').that.is.undefined;
@@ -112,7 +132,7 @@ describe('jowl cli', () => {
       runCommand(jowlCommand, [
         '--quiet',
         'p(d[0])',
-      ], '["one", "two"]', (err, result) => {
+      ], '["one", "two"]', {}, (err, result) => {
         expect(result).to.have.property('stdout', 'one\n');
         expect(result).to.have.property('status', 0);
         expect(result).to.have.property('stderr').that.is.undefined;
@@ -125,7 +145,7 @@ describe('jowl cli', () => {
       runCommand(jowlCommand, [
         '-q',
         'c.each(p)',
-      ], '["one", "two"]', (err, result) => {
+      ], '["one", "two"]', {}, (err, result) => {
         expect(result).to.have.property('stdout', 'one\ntwo\n');
         expect(result).to.have.property('status', 0);
         expect(result).to.have.property('stderr').that.is.undefined;
@@ -138,7 +158,7 @@ describe('jowl cli', () => {
   it('should have --help', (done) => {
     runCommand(jowlCommand, [
       '--help',
-    ], null, (err, result) => {
+    ], null, {}, (err, result) => {
       expect(result).to.have.property('stderr').that.is.undefined;
       expect(result).to.have.property('stdout').to.contain('--help');
       expect(result).to.have.property('stdout').to.contain('reference');
@@ -149,13 +169,62 @@ describe('jowl cli', () => {
   });
 
   it('should treat no command as passthrough', (done) => {
-    runCommand(jowlCommand, [], '["one", "two"]', (err, result) => {
+    runCommand(jowlCommand, [], '["one", "two"]', {}, (err, result) => {
       const jsonFormatted = '[\n  "one",\n  "two"\n]\n';
       expect(result).to.have.property('stdout', jsonFormatted);
       expect(result).to.have.property('stderr').that.is.undefined;
       expect(result).to.have.property('status', 0);
 
       done();
+    });
+  });
+
+  describe('color support', () => {
+    it('should output syntax-highlighted color when --color is passed', (done) => {
+      // Since we are deliberately using colors that are part of the 16 color set,
+      // chalk will output the same colors in every level other than 0
+      runCommand(jowlCommand, ['--color'], generateColorString(0), {}, (err, result) => {
+        expect(result).to.have.property('stdout', `${generateColorString(1)}\n`);
+        expect(result).to.have.property('stderr').that.is.undefined;
+        expect(result).to.have.property('status', 0);
+
+        done();
+      });
+    });
+
+    it('should not output color when -no-color is passed', (done) => {
+      // Since tests set up STDOUT to not-a-tty, we'd expect this same
+      // behavior without the flag. It's still valuable to test that
+      // the flag exists.
+      runCommand(jowlCommand, ['--no-color'], generateColorString(0), {}, (err, result) => {
+        expect(result).to.have.property('stdout', `${generateColorString(0)}\n`);
+        expect(result).to.have.property('stderr').that.is.undefined;
+        expect(result).to.have.property('status', 0);
+
+        done();
+      });
+    });
+
+    it('should output syntax-highlighted color when FORCE_COLOR=1 is passed', (done) => {
+      // Since we are deliberately using colors that are part of the 16 color set,
+      // chalk will output the same colors in every level other than 0
+      runCommand(jowlCommand, [], generateColorString(0), { FORCE_COLOR: 1 }, (err, result) => {
+        expect(result).to.have.property('stdout', `${generateColorString(1)}\n`);
+        expect(result).to.have.property('stderr').that.is.undefined;
+        expect(result).to.have.property('status', 0);
+
+        done();
+      });
+    });
+
+    it('should not output color when FORCE_COLOR=0 is passed, even when --color is passed', (done) => {
+      runCommand(jowlCommand, ['--color'], generateColorString(0), { FORCE_COLOR: 0 }, (err, result) => {
+        expect(result).to.have.property('stdout', `${generateColorString(0)}\n`);
+        expect(result).to.have.property('stderr').that.is.undefined;
+        expect(result).to.have.property('status', 0);
+
+        done();
+      });
     });
   });
 });

--- a/test/unit/lib/format.js
+++ b/test/unit/lib/format.js
@@ -38,7 +38,7 @@ describe('formatting library', () => {
       const data = { a: 'b' };
       expect(
         format.formatOutput(data)
-      ).to.equal('{\n  "a": "b"\n}');
+      ).to.equal(JSON.stringify.returnValues[0]);
 
       sinon.assert.calledOnce(JSON.stringify);
       sinon.assert.calledWithExactly(
@@ -72,7 +72,7 @@ describe('formatting library', () => {
     it('should pass arguments through to run method', () => {
       expect(
         format.runFormat(json, command)
-      ).to.equal('"one"');
+      ).to.equal(format.formatOutput.returnValues[0]);
 
       sinon.assert.calledOnce(run.run);
       sinon.assert.calledWithExactly(

--- a/test/unit/lib/format.js
+++ b/test/unit/lib/format.js
@@ -27,22 +27,31 @@ describe('formatting library', () => {
 
   describe('formatOutput method', () => {
     beforeEach(() => {
+      sinon.spy(format, 'jsonColorizer');
       sinon.spy(JSON, 'stringify');
     });
 
     afterEach(() => {
       JSON.stringify.restore();
+      format.jsonColorizer.restore();
     });
 
     it('should pretty-print the output by calling JSON.stringify', () => {
       const data = { a: 'b' };
       expect(
         format.formatOutput(data)
-      ).to.equal(JSON.stringify.returnValues[0]);
+      ).to.equal(format.jsonColorizer.returnValues[0]);
 
       sinon.assert.calledOnce(JSON.stringify);
       sinon.assert.calledWithExactly(
         JSON.stringify, sinon.match(data), null, 2
+      );
+
+      sinon.assert.calledOnce(format.jsonColorizer);
+      sinon.assert.calledWithExactly(
+        format.jsonColorizer,
+        JSON.stringify.returnValues[0],
+        sinon.match({})
       );
     });
   });

--- a/test/unit/lib/format.js
+++ b/test/unit/lib/format.js
@@ -38,11 +38,11 @@ describe('formatting library', () => {
       const data = { a: 'b' };
       expect(
         format.formatOutput(data)
-      ).to.equal('{\n    "a": "b"\n}');
+      ).to.equal('{\n  "a": "b"\n}');
 
       sinon.assert.calledOnce(JSON.stringify);
       sinon.assert.calledWithExactly(
-        JSON.stringify, sinon.match(data), null, 4
+        JSON.stringify, sinon.match(data), null, 2
       );
     });
   });

--- a/test/unit/lib/format.js
+++ b/test/unit/lib/format.js
@@ -37,7 +37,7 @@ describe('formatting library', () => {
     it('should pretty-print the output by calling JSON.stringify', () => {
       const data = { a: 'b' };
       expect(
-        format.formatOutput(data, 'd')
+        format.formatOutput(data)
       ).to.equal('{\n    "a": "b"\n}');
 
       sinon.assert.calledOnce(JSON.stringify);

--- a/yarn.lock
+++ b/yarn.lock
@@ -157,7 +157,7 @@ chai@^3.4.1:
     deep-eql "^0.1.3"
     type-detect "^1.0.0"
 
-chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.4.2:
+chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -895,6 +895,14 @@ js-yaml@^3.13.0:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
+json-colorizer@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/json-colorizer/-/json-colorizer-2.2.2.tgz#07c2ac8cef36558075948e1566c6cfb4ac1668e6"
+  integrity sha512-56oZtwV1piXrQnRNTtJeqRv+B9Y/dXAYLqBBaYl/COcUdoZxgLBLAO88+CnkbT6MxNs0c5E9mPBIb2sFcNz3vw==
+  dependencies:
+    chalk "^2.4.1"
+    lodash.get "^4.4.2"
+
 json-schema-traverse@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
@@ -962,6 +970,11 @@ lodash.flatten@~4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
   integrity sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=
+
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+  integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
 
 lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4:
   version "4.17.21"


### PR DESCRIPTION
Use json-colorizer to add ANSI color codes to syntax highlight result
data. The color scheme still needs to be tested on more terminals and
themes, but is at least reasonably readable. It is limited to the
16-color space, so no downsampling should be necessary.

Add support for the --color and --no-color options to override chalk's
heuristics on when to output color codes. dg for this other than
telling Commander to not reject them. Chalk (actually its dependency
supports-color) also supports other
values for --color but leave these undocumented until they've been
given more consideration. Commander doesn't give us a great way yet to
declare --color and--no-color being mutually exclusive, so just document
the use of both of them being undefined behavior for now so that we can
add that check later without it being a breaking change.

Also document FORCE_COLOR=1 and FORCE_COLOR=0 which are also read
directly by chalk. Don't document any other levels for the same color
depth reasons as above. Add the ability for integration tests to set environment variables to
handle testing FORCE_COLOR. Pass through a few important variables like
PATH by default to make sure that the tests will actually run.

To test this behavior, make a clearer distinction between unit tests, which
just ensure the values of called functions are being returned, and integration
tests, which actually test for the existence of color codes. This is necessary
because Chalk is doing a lot of heuristics to determine whether to output color
and we don't have complete control over all of the signals it looks for in unit tests,
and is also better because it more clearly separates the responsibilities of unit
and integration tests.

A new dependency, json-colorizer, has been added, and a new devDependency, Chalk,
has been added.

BREAKING CHANGE:

Jowl does not output pure JSON in cases that it used to; it now outputs JSON interspersed
with ANSI color codes. This will not break most use-cases because color codes will
never be output if standard out is not a TTY. Explicit control over this behavior is provided
if needed. Note that the specific ANSI color codes may change from release to release
(to tweak the color scheme for example) those changes will not be considered breaking.

Indentation is now 2 spaces instead of 4. This matches the behavior of JQ and the default
behavior of json-colorizer.