### PR TITLE
feat: add macOS support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,80 +1,46 @@
 version: 2.1
 
 workflows:
-  build-node-all:
+  all-builds:
     jobs:
-      - build-node-6 # Best effort support
-      - build-node-8 # Best effort support
-      - build-node-10 # Best effort support
-      - build-node-12 # Fully supported
-      - build-node-14 # FUlly supported
-      - build-node-16 # FUlly supported
-      - build-node-16-macos
-commands:
-  build:
-    steps:
-      - checkout
+      - build:
+          matrix:
+            parameters:
+              os:
+                - linux
+                - macos
+              node-version:
+                - "6" # Best effort support
+                - "8" # Best effort support
+                - "10" # Best effort support
+                - "12" # Fully supported
+                - "14" # Fully supported
+                - "16" # Fully supported
 
-      # Download and cache dependencies
-      - restore_cache:
-          keys:
-            - v3-dependencies-{{ checksum "package.json" }}{{ checksum "yarn.lock" }}
-            # fallback to using the latest cache if no exact match is found
-            - v3-dependencies-
+executors:
+  linux:
+    docker:
+      - image: cimg/base:2022.01 # Version chosen arbitrarily as newest at time of writing
+  macos:
+    macos:
+      xcode: 13.2.1 # Version chosen arbitrarily as newest at time of writing
 
-      - run: yarn install --frozen-lockfile
-
-      - save_cache:
-          paths:
-            - node_modules
-          key: v3-dependencies-{{ checksum "package.json" }}{{ checksum "yarn.lock" }}
-
-      - run: yarn run build
-  install-yarn:
-    steps:
-      - run: 'npm install -g yarn'
+orbs:
+  node: circleci/node@5.0.0
 
 jobs:
-  build-node-16-macos:
-    macos:
-      xcode: 13.2.1 # we don't care about the version but there needs to be something here
+  build:
+    parameters:
+      os:
+        type: executor
+      node-version:
+        type: string
+    executor: << parameters.os >>
     steps:
       - checkout
-      - run: yarn install
-    working_directory: ~/jowl
-  build-node-6:
-    docker:
-      - image: circleci/node:6
-    working_directory: ~/jowl
-    steps:
-      - build
-  build-node-8:
-    docker:
-      - image: circleci/node:8
-    working_directory: ~/jowl
-    steps:
-      - build
-  build-node-10:
-    docker:
-      - image: circleci/node:10
-    working_directory: ~/jowl
-    steps:
-      - build
-  build-node-12:
-    docker:
-      - image: circleci/node:12
-    working_directory: ~/jowl
-    steps:
-      - build
-  build-node-14:
-    docker:
-      - image: circleci/node:14
-    working_directory: ~/jowl
-    steps:
-      - build
-  build-node-16:
-    docker:
-      - image: circleci/node:16
-    working_directory: ~/jowl
-    steps:
-      - build
+      - node/install:
+          node-version: << parameters.node-version >>
+          install-yarn: true
+      - node/install-packages:
+          pkg-manager: yarn
+      - run: yarn run build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,7 @@ workflows:
       - build-node-12 # Fully supported
       - build-node-14 # FUlly supported
       - build-node-16 # FUlly supported
+      - build-node-16-macos
 commands:
   build:
     steps:
@@ -34,6 +35,13 @@ commands:
       - run: 'npm install -g yarn'
 
 jobs:
+  build-node-16-macos:
+    macos:
+      xcode: 13.2.1 # we don't care about the version but there needs to be something here
+    steps:
+      - checkout
+      - run: yarn install
+    working_directory: ~/jowl
   build-node-6:
     docker:
       - image: circleci/node:6

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-[![Linux Build Status](https://circleci.com/gh/daxelrod/jowl.svg?style=svg)](https://circleci.com/gh/daxelrod/jowl) [![Windows Build Status](https://ci.appveyor.com/api/projects/status/awi03ipcuan2ttco/branch/master?svg=true)](https://ci.appveyor.com/project/daxelrod/jowl)
+[![Linux & macOS Build Status](https://circleci.com/gh/daxelrod/jowl.svg?style=svg)](https://circleci.com/gh/daxelrod/jowl) [![Windows Build Status](https://ci.appveyor.com/api/projects/status/awi03ipcuan2ttco/branch/master?svg=true)](https://ci.appveyor.com/project/daxelrod/jowl)
 
 I'm glad you find Jowl useful enough that you want to help out! Thank you!
 
@@ -58,7 +58,7 @@ First, ensure the following dependencies are installed:
    Note that build output may be a little difficult to read as [lines from different tests are interleaved](https://github.com/daxelrod/jowl/issues/1).
    Sorry about that.
 
-   If the build doesn't pass, but [Linux](https://circleci.com/gh/daxelrod/jowl) and [Windows](https://ci.appveyor.com/project/daxelrod/jowl) Continuous Integration show the same commit passing, there's either something wrong with your development environment, or your platform is different than the ones Jowl is tested on.
+   If the build doesn't pass, but [Linux, macOS](https://circleci.com/gh/daxelrod/jowl) and [Windows](https://ci.appveyor.com/project/daxelrod/jowl) Continuous Integration show the same commit passing, there's either something wrong with your development environment, or your platform is different than the ones Jowl is tested on.
    Feel free to file an issue (and link to the Continuous Integration build for the commit) and we'll get to the bottom of it.
 1. Ensure your text editor is using LF (Unix) line endings.
 1. [Write a test](#testing) for your new behavior and verify that it fails.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ Jowl's goals are:
 
 ## Installation
 
+### macOS or Linux via Homebrew
+
+Install [Homebrew](https://brew.sh/). Then run:
+
+```bash
+brew install daxelrod/jowl/jowl
+```
+
+### macOS, Linux, or Windows via NPM
+
 Jowl requires [NodeJS](https://nodejs.org/en/download/)(all LTS versions are supported) running on either Unix or Windows.
 
 ```bash


### PR DESCRIPTION
Test on macOS on all the same versions that we test on Linux.

Implement this via CircleCI matrix builds and by switching to the node Orb.
While we're at it, bump the version of the container used in CircleCI.

Document that Homebrew installation is available for macOS and Linux. The
actual implemenation of a Homebrew tap is in
https://github.com/daxelrod/homebrew-jowl/ because Homebrew requires a
separate repository with a particular name.