### PR TITLE
fix(format): improve color contrast

### DIFF
--- a/src/lib/format.js
+++ b/src/lib/format.js
@@ -22,8 +22,8 @@ format.formatOutput = function formatOutput(resultData) {
     colors: {
       STRING_KEY: 'cyan', // On terminals where pure blue defaults to 0000FF, it can be hard to read against black
       STRING_LITERAL: 'reset', // The default color is likely to be the most readable
-      NUMBER_LITERAL: 'green.bold',
-      BOOLEAN_LITERAL: 'magenta', // Don't want to make this red or green because of associations with true and false
+      NUMBER_LITERAL: 'green', // green.bold did not have enough contrast on many color schemes
+      BOOLEAN_LITERAL: 'magentaBright', // Don't want to make this red or green because of associations with true and false; magenta had too little contrast
       NULL_LITERAL: 'red',
       BRACE: 'reset', // Because of indentation, visually distinct anyway
       BRACKET: 'reset', // Same as brace

--- a/test/integration/jowl.js
+++ b/test/integration/jowl.js
@@ -56,8 +56,8 @@ function generateColorString(chalkLevel) {
   const chalk = new globalChalk.constructor({ level: chalkLevel });
   return `${chalk.reset('{')}
   ${chalk.cyan('"STRING_LITERAL"')}${chalk.reset(':')} ${chalk.reset('"yay a string"')}${chalk.gray(',')}
-  ${chalk.cyan('"NUMBER_LITERAL"')}${chalk.reset(':')} ${chalk.green.bold('12.1')}${chalk.gray(',')}
-  ${chalk.cyan('"BOOLEAN_LITERAL"')}${chalk.reset(':')} ${chalk.magenta('true')}${chalk.gray(',')}
+  ${chalk.cyan('"NUMBER_LITERAL"')}${chalk.reset(':')} ${chalk.green('12.1')}${chalk.gray(',')}
+  ${chalk.cyan('"BOOLEAN_LITERAL"')}${chalk.reset(':')} ${chalk.magentaBright('true')}${chalk.gray(',')}
   ${chalk.cyan('"NULL_LITERAL"')}${chalk.reset(':')} ${chalk.red('null')}${chalk.gray(',')}
   ${chalk.cyan('"BRACKET"')}${chalk.reset(':')} ${chalk.reset('[')}${chalk.reset(']')}
 ${chalk.reset('}')}`;


### PR DESCRIPTION
Testing Jowl's output across a variety of terminals' built in color
schemes revealed several cases in which the text color did not have
enough contrast against the background. Since we don't have a great way
of determining whether the current terminal color scheme uses dark text
on a light background or vice versa, we can't fix this by setting a
background color without making output clash with user preferences.

Use 'green' rather than 'green.bold' for numeric literals. This seems
to have come from color schemes treating what ECMA 48 describes as
"bold or increased intensity" as meaning a brighter color, rather than
more contrast. green.bold was not high enough contrast on:

* Konsole
  * "Black on Light Yellow"
  * "Black on White"
* iTerm2
  * "Light Background"
  * "Tango Light"

Additionally, use 'magentaBright' rather than just 'magenta'. Several
popular color schemes do not have enough contrast with magenta text
against a dark background:

* Linux virtual console
* Gnome Terminal, "Use Colors from System Theme" + "Tango" Palette
* Powershell, blue background
* macOS Terminal, "Ocean"

There were a few color schemes where 'red' was also hard to read.
However, they would also be unusable for tools that do color diffs, so
this seems not worth fixing.

Fixes #39.