### PR TITLE
chore(ci): prevent "No workflow" on release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,11 @@ workflows:
                 - "12" # Fully supported
                 - "14" # Fully supported
                 - "16" # Fully supported
+          filters:
+            # Runs on all branches by default
+            # Runs on no tags by default, so must add version tags to allow deploy jobs to run
+            tags:
+              only: /^v.*/
       - deploy-npm:
           requires:
             - build


### PR DESCRIPTION
Fix a bug in CI where no jobs run by default, so build jobs wouldn't
run, so npm-publish wouldn't run because it depends on build jobs,
leading to CircleCI reporting "No workflow" when a tag is pushed.