### PR TITLE
chore(ci): add automatic brew tap bumps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,17 @@ workflows:
             # Necessary to prevent building on every branch even though tags are restricted
             branches:
               ignore: /.*/
-
+      - deploy-homebrew:
+          requires:
+            # Homebrew automation depends on pulling the published package from npmjs.org
+            - deploy-npm
+          filters:
+            # Only version tags
+            tags:
+              only: /^v.*/
+            # Necessary to prevent building on every branch even though tags are restricted
+            branches:
+              ignore: /.*/
 
 executors:
   linux:
@@ -111,3 +121,21 @@ jobs:
           node-version: "16"
       - run: npm config set "//registry.npmjs.org/:_authToken=$NPM_TOKEN"
       - run: npm publish
+  deploy-homebrew:
+    docker:
+      - image: homebrew/brew:3.3.15 # Version chosen arbitrarily as newest at time of writing
+    steps:
+      - run: |
+          export JOWL_VERSION="$(echo ${CIRCLE_TAG} | sed 's/^v//')"
+          git config --global user.email "git@danonline.net"
+          git config --global user.name "Daniel Axelrod (via CircleCI)"
+          export HOMEBREW_NO_ANALYTICS=1 HOMEBREW_NO_AUTO_UPDATE=1
+          brew tap daxelrod/jowl
+          brew bump-formula-pr daxelrod/jowl/jowl --version="${JOWL_VERSION}" --write-only --commit
+          brew audit daxelrod/jowl/jowl --strict
+          cd "$(dirname $(brew formula daxelrod/jowl/jowl))"
+          # bump-formula-pr --message only affects the PR message, not the commit message
+          git commit --amend -m "chore(release): jowl ${JOWL_VERSION}" -m "" -m "Created automatically by deploy-homebrew CircleCI job in main jowl repo"
+          git --no-pager show
+          # Authenticated with deploy key in CircleCI project settings
+          git push


### PR DESCRIPTION
Add new deploy-homebrew job to bump the version and checksum in the brew
tap and push the new commit automatically after publishing to npmjs.org.

The closest brew command to do this is "bump-formula-pr", intended to
open a pull request with the formula update. We instead invoke it but
tell it just to make the formula changes and commit them to homebrew's
checked out working directory for the tap. We pass the version (derived
from the tag) explicitly, both to avoid race conditions with the
registry, and also because "bump-formula-pr" can't figure out the new
version even though "bump" can.