### PR TITLE
chore(ci): fix brew and fedora publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,6 +126,9 @@ jobs:
     docker:
       - image: homebrew/brew:3.3.15 # Version chosen arbitrarily as newest at time of writing
     steps:
+      - add_ssh_keys:
+          fingerprints:
+            - "56:e9:ae:84:c0:ae:f2:55:2a:9a:f9:73:8a:0d:06:f4" # "CircleCI Push" Deploy Key in Github
       - run: |
           export JOWL_VERSION="$(echo ${CIRCLE_TAG} | sed 's/^v//')"
           git config --global user.email "git@danonline.net"
@@ -138,5 +141,4 @@ jobs:
           # bump-formula-pr --message only affects the PR message, not the commit message
           git commit --amend -m "chore(release): jowl ${JOWL_VERSION}" -m "" -m "Created automatically by deploy-homebrew CircleCI job in main jowl repo"
           git --no-pager show
-          # Authenticated with deploy key in CircleCI project settings
           git push

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -5,9 +5,12 @@ specfile_path: dist/jowl.spec
 
 # add or remove files that should be synced
 files_to_sync:
+  - .packit.yaml
+  - src:
     - dist/jowl.spec
     - dist/packit-fix-spec-file.sh
-    - .packit.yaml
+    dest: dist/
+    mkpath: true
 
 # name in upstream package repository or registry (e.g. in PyPI)
 upstream_package_name: jowl


### PR DESCRIPTION
Explicitly specify which SSH key to use in CircleCI to push to homebrew-jowl repo.
At some point, CircleCI switched from implicitly adding SSH keys
configured in the project to the job's environment to not adding
keys unless they were explicitly specified.

When packit syncs files from this repo to Fedora's dist-git, explicitly
tell it to create the destination dist/ directory if it does not already
exist. It is an explicit design decision to require mkpath to be specified for
packit to create directories. See https://github.com/packit/packit/issues/1738
for more information.

