### PR TITLE
chore(ci): fix packit propose-downstream

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,6 @@ executors:
       - image: cimg/base:2022.01 # Version chosen arbitrarily as newest at time of writing
   macos: &macos-executor
     macos:
-      resource_class: macos.x86.medium.gen2
       xcode: 14.3.1 # Version chosen arbitrarily as newest at time of writing
   # Circle's docs recommend using the executor definition from the windows orb. However, it does
   # not appear to be possible to use that in an executors section that is compatible with matrix builds,

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -7,6 +7,11 @@ specfile_path: dist/jowl.spec
 files_to_sync:
   - .packit.yaml
   - src:
+    - dist/jowl-*-bundled-licenses.txt
+    - dist/jowl-*-nm-dev.tgz
+    - dist/jowl-*-nm-prod.tgz
+    dest: .
+  - src:
     - dist/jowl.spec
     - dist/packit-post-upstream-clone.sh
     dest: dist/


### PR DESCRIPTION
During propose-downstream, packit expects the generated source files to be in the root
of the dist-git repo, so use the correct parameters to put them there during rsync.

Also remove x86_64 instance spec for macOS builds to fix CircleCI.